### PR TITLE
Support indexed LEAPP state inputs

### DIFF
--- a/scripts/reinforcement_learning/leapp/debug_compare_rsl_leapp.py
+++ b/scripts/reinforcement_learning/leapp/debug_compare_rsl_leapp.py
@@ -1,0 +1,381 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Compare a live RSL-RL checkpoint against a LEAPP export on the same env state.
+
+This is a debugging helper for LEAPP deployment mismatches.  It drives one
+standard Isaac Lab/RSL-RL environment, evaluates both the live PyTorch policy
+and the LEAPP InferenceManager from the same simulator tensors, then steps the
+reference environment with the live RSL action.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import importlib.metadata as metadata
+import os
+import sys
+import traceback
+from pathlib import Path
+
+from isaaclab.app import AppLauncher
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compare live RSL-RL and LEAPP policy outputs.")
+    parser.add_argument("--task", type=str, required=True, help="Registered Isaac Lab task.")
+    parser.add_argument("--checkpoint", type=str, required=True, help="Path to RSL-RL checkpoint.")
+    parser.add_argument("--leapp_model", type=str, required=True, help="Path to LEAPP YAML pipeline.")
+    parser.add_argument("--agent", type=str, default="rsl_rl_cfg_entry_point", help="Agent config registry key.")
+    parser.add_argument("--num_steps", type=int, default=8, help="Number of comparison steps.")
+    parser.add_argument("--num_envs", type=int, default=1, help="Number of envs. Keep this at 1 for LEAPP export.")
+    parser.add_argument("--seed", type=int, default=None, help="Optional env seed override.")
+    parser.add_argument(
+        "--csv",
+        type=str,
+        default=None,
+        help="Optional CSV output path for per-step diff metrics.",
+    )
+    AppLauncher.add_app_launcher_args(parser)
+    return parser.parse_args()
+
+
+args_cli = parse_args()
+
+app_launcher = AppLauncher(args_cli)
+simulation_app = app_launcher.app
+
+import gymnasium as gym
+import onnx
+import torch
+import yaml
+from leapp import InferenceManager
+from onnx import numpy_helper
+from rsl_rl.runners import DistillationRunner, OnPolicyRunner
+
+import isaaclab_tasks  # noqa: F401
+from isaaclab.envs.leapp_deployment_env import _resolve_joint_ids
+from isaaclab_rl.rsl_rl import RslRlVecEnvWrapper, handle_deprecated_rsl_rl_cfg
+from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry
+
+_RSL_RL_SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "rsl_rl"
+if str(_RSL_RL_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_RSL_RL_SCRIPTS_DIR))
+
+
+def log(*args):
+    print(*args, flush=True)
+
+
+def policy_module(policy):
+    """Return the module behind an inference callable when available."""
+    return getattr(policy, "__self__", policy)
+
+
+def is_recurrent_policy(policy) -> bool:
+    module = policy_module(policy)
+    return bool(getattr(module, "is_recurrent", False) or hasattr(module, "memory_a"))
+
+
+def _clone_state(state):
+    if state is None:
+        return None
+    if isinstance(state, tuple):
+        return tuple(t.clone() for t in state)
+    return state.clone()
+
+
+def clone_hidden_state(policy):
+    if not is_recurrent_policy(policy):
+        return None
+    module = policy_module(policy)
+    if hasattr(module, "get_hidden_state"):
+        state = module.get_hidden_state()
+    elif hasattr(module, "get_hidden_states"):
+        state, _ = module.get_hidden_states()
+    elif hasattr(module, "memory_a"):
+        state = module.memory_a.hidden_state
+    else:
+        return None
+    return _clone_state(state)
+
+
+def restore_hidden_state(policy, state):
+    if not is_recurrent_policy(policy):
+        return
+    module = policy_module(policy)
+    if hasattr(module, "memory_a"):
+        module.memory_a.hidden_state = _clone_state(state)
+    elif state is None:
+        module.reset()
+    else:
+        module.reset(hidden_state=_clone_state(state))
+
+
+def tensor_preview(tensor: torch.Tensor, limit: int = 6) -> str:
+    flat = tensor.detach().flatten().cpu()
+    values = ", ".join(f"{float(v):+.5f}" for v in flat[:limit])
+    suffix = ", ..." if flat.numel() > limit else ""
+    return f"[{values}{suffix}]"
+
+
+def diff_stats(a: torch.Tensor, b: torch.Tensor) -> dict[str, float]:
+    a = a.detach().to(device="cpu", dtype=torch.float32)
+    b = b.detach().to(device="cpu", dtype=torch.float32)
+    diff = (a - b).abs()
+    return {
+        "max": float(diff.max().item()),
+        "mean": float(diff.mean().item()),
+        "rms": float(torch.sqrt(torch.mean(diff * diff)).item()),
+    }
+
+
+def _extract_observation_term(env, obs: dict[str, torch.Tensor], group_name: str, term_name: str) -> torch.Tensor:
+    """Extract one observation term from a live observation buffer."""
+    if group_name not in obs:
+        raise KeyError(f"Observation group '{group_name}' not found in live obs keys: {list(obs.keys())}")
+
+    observation_manager = env.unwrapped.observation_manager
+    group_obs = obs[group_name]
+    if not observation_manager.group_obs_concatenate[group_name]:
+        return group_obs[term_name].detach().clone()
+
+    group_term_names = observation_manager._group_obs_term_names[group_name]
+    group_term_dims = observation_manager._group_obs_term_dim[group_name]
+    term_index = group_term_names.index(term_name)
+    concat_dim = observation_manager._group_obs_concatenate_dim[group_name]
+    term_dim = concat_dim - 1 if concat_dim > 0 else concat_dim
+    start = sum(dims[term_dim] for dims in group_term_dims[:term_index])
+    length = group_term_dims[term_index][term_dim]
+    return group_obs.narrow(dim=concat_dim, start=start, length=length).detach().clone()
+
+
+def resolve_leapp_inputs(
+    env, inference: InferenceManager, yaml_desc: dict, obs: dict[str, torch.Tensor] | None = None
+) -> dict[str, torch.Tensor]:
+    inputs = {}
+    pipeline_inputs = yaml_desc["pipeline"]["inputs"]
+    for node_name, input_names in pipeline_inputs.items():
+        node = inference.nodes[node_name]
+        desc_by_name = {d["name"]: d for d in node.input_descriptions}
+        for input_name in input_names:
+            desc = desc_by_name[input_name]
+            connection = desc.get("isaaclab_connection")
+            if connection is None:
+                continue
+            parts = connection.split(":")
+            if parts[0] == "state":
+                entity_name, prop_name = parts[1], parts[2]
+                entity = env.unwrapped.scene[entity_name]
+                value = getattr(entity.data, prop_name).torch
+                joint_ids = _resolve_joint_ids(desc.get("element_names"), entity)
+                if joint_ids is not None:
+                    value = value[:, joint_ids]
+            elif parts[0] == "observation":
+                if obs is None:
+                    raise RuntimeError(f"Live obs is required to resolve LEAPP input: {connection}")
+                group_name, term_name = parts[1], parts[2]
+                value = _extract_observation_term(env, obs, group_name, term_name)
+            else:
+                raise NotImplementedError(f"Unsupported input connection in debug helper: {connection}")
+            inputs[f"{node_name}/{input_name}"] = value.detach().clone()
+    return inputs
+
+
+def get_model_output(outputs: dict[str, torch.Tensor], suffix: str) -> torch.Tensor:
+    matches = [value for key, value in outputs.items() if key.endswith(f"/{suffix}")]
+    if len(matches) != 1:
+        raise RuntimeError(f"Expected exactly one LEAPP output ending in '/{suffix}', found {len(matches)}")
+    return matches[0]
+
+
+def get_onnx_constant0(yaml_path: str, yaml_desc: dict) -> torch.Tensor | None:
+    models = yaml_desc.get("models", {})
+    if not models:
+        return None
+    model_desc = next(iter(models.values()))
+    model_path = os.path.join(os.path.dirname(yaml_path), model_desc["parameters"]["model_path"])
+    graph = onnx.load(model_path).graph
+    for init in graph.initializer:
+        if init.name == "_tensor_constant0":
+            return torch.from_numpy(numpy_helper.to_array(init).copy()).to(dtype=torch.float32)
+    return None
+
+
+def with_baked_shaft_pos(obs, baked_shaft_pos: torch.Tensor | None):
+    obs_copy = copy.deepcopy(obs)
+    if baked_shaft_pos is not None and baked_shaft_pos.shape[-1] == 3:
+        obs_copy["policy"][:, 12:15] = baked_shaft_pos.to(device=obs_copy["policy"].device, dtype=obs_copy["policy"].dtype)
+    return obs_copy
+
+
+def evaluate_policy_with_state(policy, state, obs):
+    restore_hidden_state(policy, state)
+    return policy(copy.deepcopy(obs))
+
+
+def expected_relative_joint_target(env, actions: torch.Tensor, clip_actions: float | None) -> torch.Tensor:
+    action_term = env.unwrapped.action_manager._terms["arm_action"]
+    arm_joint_ids = action_term._joint_ids
+    scale = action_term._scale
+    if not torch.is_tensor(scale):
+        scale = torch.tensor(scale, device=actions.device, dtype=actions.dtype)
+    clipped = torch.clamp(actions, -clip_actions, clip_actions) if clip_actions is not None else actions
+    processed = clipped[:, : len(arm_joint_ids)] * scale
+    current_joint_pos = env.unwrapped.scene["robot"].data.joint_pos.torch[:, arm_joint_ids]
+    return current_joint_pos + processed
+
+
+def maybe_write_csv_header(path: str | None):
+    if path is None:
+        return
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(
+            "step,rsl_vs_leapp_max,rsl_vs_leapp_mean,rsl_vs_leapp_rms,"
+            "zero_vs_leapp_max,zero_vs_leapp_mean,zero_vs_leapp_rms,"
+            "rsl_vs_zero_max,rsl_vs_zero_mean,rsl_vs_zero_rms\n"
+        )
+
+
+def append_csv(path: str | None, step: int, rsl_leapp: dict, zero_leapp: dict, rsl_zero: dict):
+    if path is None:
+        return
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(
+            f"{step},{rsl_leapp['max']:.9g},{rsl_leapp['mean']:.9g},{rsl_leapp['rms']:.9g},"
+            f"{zero_leapp['max']:.9g},{zero_leapp['mean']:.9g},{zero_leapp['rms']:.9g},"
+            f"{rsl_zero['max']:.9g},{rsl_zero['mean']:.9g},{rsl_zero['rms']:.9g}\n"
+        )
+
+
+def main():
+    task_name = args_cli.task.split(":")[-1]
+    log("[COMPARE] loading env config")
+    env_cfg = load_cfg_from_registry(task_name, "env_cfg_entry_point")
+    log("[COMPARE] loading agent config")
+    agent_cfg = load_cfg_from_registry(task_name, args_cli.agent)
+
+    # Match the play.py config path closely.
+    if args_cli.seed is not None:
+        agent_cfg.seed = args_cli.seed
+    if args_cli.device is not None:
+        agent_cfg.device = args_cli.device
+    agent_cfg = handle_deprecated_rsl_rl_cfg(agent_cfg, metadata.version("rsl-rl-lib"))
+    env_cfg.scene.num_envs = args_cli.num_envs
+    env_cfg.seed = args_cli.seed if args_cli.seed is not None else agent_cfg.seed
+    env_cfg.sim.device = args_cli.device if args_cli.device is not None else env_cfg.sim.device
+    env_cfg.log_dir = os.path.dirname(args_cli.checkpoint)
+
+    log("[COMPARE] creating gym env")
+    env = gym.make(args_cli.task, cfg=env_cfg, render_mode=None)
+    log("[COMPARE] wrapping env for RSL-RL")
+    env = RslRlVecEnvWrapper(env, clip_actions=agent_cfg.clip_actions)
+
+    log("[COMPARE] constructing RSL-RL runner")
+    if agent_cfg.class_name == "OnPolicyRunner":
+        runner = OnPolicyRunner(env, agent_cfg.to_dict(), log_dir=None, device=agent_cfg.device)
+    elif agent_cfg.class_name == "DistillationRunner":
+        runner = DistillationRunner(env, agent_cfg.to_dict(), log_dir=None, device=agent_cfg.device)
+    else:
+        raise ValueError(f"Unsupported runner class: {agent_cfg.class_name}")
+
+    log("[COMPARE] loading checkpoint")
+    runner.load(args_cli.checkpoint)
+    policy = runner.get_inference_policy(device=env.unwrapped.device)
+    log("[COMPARE] loading LEAPP inference manager")
+    inference = InferenceManager(args_cli.leapp_model)
+    with open(args_cli.leapp_model, encoding="utf-8") as f:
+        leapp_yaml = yaml.safe_load(f)
+    baked_shaft_pos = get_onnx_constant0(args_cli.leapp_model, leapp_yaml)
+
+    log("[COMPARE] task:", args_cli.task)
+    log("[COMPARE] checkpoint:", args_cli.checkpoint)
+    log("[COMPARE] leapp_model:", args_cli.leapp_model)
+    log("[COMPARE] recurrent policy:", is_recurrent_policy(policy))
+    log("[COMPARE] yaml feedback_flow:", leapp_yaml.get("pipeline", {}).get("feedback_flow"))
+    log("[COMPARE] yaml inputs:", leapp_yaml.get("pipeline", {}).get("inputs"))
+    log("[COMPARE] yaml outputs:", leapp_yaml.get("pipeline", {}).get("outputs"))
+    log(
+        "[COMPARE] onnx _tensor_constant0:",
+        None if baked_shaft_pos is None else f"shape={tuple(baked_shaft_pos.shape)} {tensor_preview(baked_shaft_pos, 3)}",
+    )
+
+    maybe_write_csv_header(args_cli.csv)
+
+    obs = env.get_observations()
+    try:
+        for step in range(args_cli.num_steps):
+            with torch.inference_mode():
+                # Evaluate a zero-memory version without disturbing the carried policy state.
+                carried_state = clone_hidden_state(policy)
+                zero_actions = evaluate_policy_with_state(policy, None, obs)
+                zero_target = expected_relative_joint_target(env, zero_actions, agent_cfg.clip_actions)
+                zero_baked_actions = evaluate_policy_with_state(policy, None, with_baked_shaft_pos(obs, baked_shaft_pos))
+                zero_baked_target = expected_relative_joint_target(env, zero_baked_actions, agent_cfg.clip_actions)
+                carried_baked_actions = evaluate_policy_with_state(
+                    policy, carried_state, with_baked_shaft_pos(obs, baked_shaft_pos)
+                )
+                carried_baked_target = expected_relative_joint_target(
+                    env, carried_baked_actions, agent_cfg.clip_actions
+                )
+                restore_hidden_state(policy, carried_state)
+
+                # Evaluate the actual carried-memory policy.
+                rsl_actions = policy(obs)
+                rsl_target = expected_relative_joint_target(env, rsl_actions, agent_cfg.clip_actions)
+
+                leapp_inputs = resolve_leapp_inputs(env, inference, leapp_yaml, obs)
+                leapp_outputs = inference.run_policy(leapp_inputs)
+                leapp_target = get_model_output(leapp_outputs, "arm_action").to(rsl_target.device)
+
+                rsl_leapp = diff_stats(rsl_target, leapp_target)
+                zero_leapp = diff_stats(zero_target, leapp_target)
+                rsl_zero = diff_stats(rsl_target, zero_target)
+                zero_baked_leapp = diff_stats(zero_baked_target, leapp_target)
+                carried_baked_leapp = diff_stats(carried_baked_target, leapp_target)
+
+                policy_obs = obs["policy"].detach().clone()
+                shaft_pos = policy_obs[:, 12:15]
+                shaft_quat = policy_obs[:, 15:19]
+
+                log(
+                    f"[COMPARE][step {step:03d}] "
+                    f"rsl-vs-leapp max={rsl_leapp['max']:.6g} mean={rsl_leapp['mean']:.6g} rms={rsl_leapp['rms']:.6g} | "
+                    f"zero-vs-leapp max={zero_leapp['max']:.6g} mean={zero_leapp['mean']:.6g} rms={zero_leapp['rms']:.6g} | "
+                    f"rsl-vs-zero max={rsl_zero['max']:.6g} mean={rsl_zero['mean']:.6g} rms={rsl_zero['rms']:.6g}"
+                )
+                log(
+                    f"[COMPARE][step {step:03d}] "
+                    f"zero_baked-vs-leapp max={zero_baked_leapp['max']:.6g} "
+                    f"mean={zero_baked_leapp['mean']:.6g} rms={zero_baked_leapp['rms']:.6g} | "
+                    f"carried_baked-vs-leapp max={carried_baked_leapp['max']:.6g} "
+                    f"mean={carried_baked_leapp['mean']:.6g} rms={carried_baked_leapp['rms']:.6g}"
+                )
+                log(f"[COMPARE][step {step:03d}] obs_policy={tensor_preview(policy_obs, 19)}")
+                log(
+                    f"[COMPARE][step {step:03d}] shaft_pos={tensor_preview(shaft_pos, 3)} "
+                    f"shaft_quat={tensor_preview(shaft_quat, 4)}"
+                )
+                log(f"[COMPARE][step {step:03d}] rsl_target={tensor_preview(rsl_target, 6)}")
+                log(f"[COMPARE][step {step:03d}] leapp_target={tensor_preview(leapp_target, 6)}")
+
+                append_csv(args_cli.csv, step, rsl_leapp, zero_leapp, rsl_zero)
+
+                obs, _, dones, _ = env.step(rsl_actions)
+                if getattr(policy, "is_recurrent", False):
+                    policy.reset(dones)
+    finally:
+        env.close()
+
+
+if __name__ == "__main__":
+    try:
+        try:
+            main()
+        except Exception:
+            traceback.print_exc()
+            raise
+    finally:
+        simulation_app.close()

--- a/source/isaaclab/isaaclab/utils/leapp/export_annotator.py
+++ b/source/isaaclab/isaaclab/utils/leapp/export_annotator.py
@@ -103,7 +103,7 @@ class ExportPatcher:
         self.task_name: str | None = None
         self.export_method = export_method
         self.required_obs_groups = required_obs_groups
-        self._annotated_tensor_cache: dict[tuple[int, str], TracedProxyArray] = {}
+        self._annotated_tensor_cache: dict[tuple, TracedProxyArray | torch.Tensor] = {}
         self._data_property_resolution_cache: dict[tuple[type, str], tuple[Callable, object] | None] = {}
         self._write_method_resolution_cache: dict[
             tuple[type, str], tuple[Callable, object, inspect.Signature] | None

--- a/source/isaaclab/isaaclab/utils/leapp/proxy.py
+++ b/source/isaaclab/isaaclab/utils/leapp/proxy.py
@@ -178,6 +178,7 @@ class _DataProxy:
             entity_name=object.__getattribute__(self, "_entity_name"),
             property_name=name,
             task_name=object.__getattribute__(self, "_task_name"),
+            cache=cache,
         )
         cache[cache_key] = traced
         return traced

--- a/source/isaaclab/isaaclab/utils/leapp/utils.py
+++ b/source/isaaclab/isaaclab/utils/leapp/utils.py
@@ -14,11 +14,146 @@ from leapp.utils.tensor_description import TensorSemantics
 
 from isaaclab.utils.warp.proxy_array import ProxyArray
 
-from .leapp_semantics import LeappTensorSemantics, resolve_leapp_element_names
+from .leapp_semantics import LeappTensorSemantics, resolve_leapp_element_names, select_element_names
+
+
+def _normalize_index(index: Any) -> Any:
+    """Return a hashable representation of a tensor index."""
+    if isinstance(index, slice):
+        return ("slice", index.start, index.stop, index.step)
+    if index is Ellipsis:
+        return ("ellipsis",)
+    if index is None:
+        return ("none",)
+    if isinstance(index, torch.Tensor):
+        return (
+            "tensor",
+            tuple(index.detach().cpu().reshape(-1).tolist()),
+            str(index.dtype),
+            tuple(index.shape),
+        )
+    if isinstance(index, list | tuple):
+        return tuple(_normalize_index(value) for value in index)
+    if isinstance(index, int):
+        return ("int", int(index))
+    return ("value", index)
+
+
+def _is_full_slice(index: Any) -> bool:
+    """Return whether *index* selects the full axis."""
+    return isinstance(index, slice) and index == slice(None)
+
+
+def _element_axis_index(selection: Any) -> Any | None:
+    """Return the tensor index that applies to the first semantic element axis.
+
+    LEAPP tensor semantics describe the non-batch axes. Isaac Lab state tensors
+    are batch-first, so ``tensor[:, joint_ids]`` maps ``joint_ids`` to element
+    names axis 0.
+    """
+    if selection is None:
+        return None
+    if not isinstance(selection, tuple):
+        return selection
+    if len(selection) < 2:
+        return None
+    return selection[1]
+
+
+def _select_semantic_element_names(element_names: list | None, selection: Any) -> list | None:
+    """Select semantic element names for an indexed tensor view."""
+    if element_names is None:
+        return None
+    axis_index = _element_axis_index(selection)
+    if axis_index is None or _is_full_slice(axis_index):
+        return element_names
+
+    if all(isinstance(name, str) for name in element_names):
+        return select_element_names(element_names, axis_index)
+    if all(isinstance(axis_names, list) for axis_names in element_names):
+        selected = list(element_names)
+        selected[0] = select_element_names(element_names[0], axis_index)
+        return selected
+    return element_names
+
+
+class LazyTracedTensor:
+    """Lazily annotate a state tensor when its final indexed value is known."""
+
+    def __init__(
+        self,
+        tensor: torch.Tensor,
+        *,
+        input_name: str,
+        semantics_meta: LeappTensorSemantics,
+        real_data: Any,
+        entity_name: str,
+        property_name: str,
+        task_name: str,
+        cache: dict,
+    ) -> None:
+        self._tensor = tensor
+        self._input_name = input_name
+        self._semantics_meta = semantics_meta
+        self._real_data = real_data
+        self._entity_name = entity_name
+        self._property_name = property_name
+        self._task_name = task_name
+        self._cache = cache
+
+    def _annotate(self, selection: Any = None) -> torch.Tensor:
+        cache_key = (
+            id(self._real_data),
+            self._property_name,
+            _normalize_index(selection),
+        )
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+
+        ref = self._tensor if selection is None else self._tensor[selection]
+        element_names = _select_semantic_element_names(
+            resolve_leapp_element_names(self._semantics_meta, self._real_data),
+            selection,
+        )
+        sem = TensorSemantics(
+            name=self._input_name,
+            ref=ref,
+            kind=self._semantics_meta.kind,
+            element_names=element_names,
+            extra=build_state_connection(self._entity_name, self._property_name),
+        )
+        annotated = annotate.input_tensors(self._task_name, sem)
+        self._cache[cache_key] = annotated
+        return annotated
+
+    def __getitem__(self, selection: Any) -> torch.Tensor:
+        return self._annotate(selection)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._annotate(), name)
+
+    @classmethod
+    def __torch_function__(cls, func, types, args=(), kwargs=None):
+        """Materialize lazy tensors when they participate in torch operations."""
+        if kwargs is None:
+            kwargs = {}
+
+        def unwrap(value):
+            if isinstance(value, cls):
+                return value._annotate()
+            if isinstance(value, tuple):
+                return tuple(unwrap(item) for item in value)
+            if isinstance(value, list):
+                return [unwrap(item) for item in value]
+            if isinstance(value, dict):
+                return {key: unwrap(item) for key, item in value.items()}
+            return value
+
+        return func(*unwrap(args), **unwrap(kwargs))
 
 
 class TracedProxyArray(ProxyArray):
-    _traced_array: torch.Tensor
+    _traced_array: LazyTracedTensor
 
     def __init__(
         self,
@@ -30,21 +165,24 @@ class TracedProxyArray(ProxyArray):
         entity_name: str,
         property_name: str,
         task_name: str,
+        cache: dict,
     ) -> None:
         super().__init__(proxy_array.warp)
         astorch = super().torch
-        sem = TensorSemantics(
-            name=input_name,
-            ref=astorch,
-            kind=semantics_meta.kind,
-            element_names=resolve_leapp_element_names(semantics_meta, real_data),
-            extra=build_state_connection(entity_name, property_name),
+        traced = LazyTracedTensor(
+            astorch,
+            input_name=input_name,
+            semantics_meta=semantics_meta,
+            real_data=real_data,
+            entity_name=entity_name,
+            property_name=property_name,
+            task_name=task_name,
+            cache=cache,
         )
-        annotated = annotate.input_tensors(task_name, sem)
-        object.__setattr__(self, "_traced_array", annotated)
+        object.__setattr__(self, "_traced_array", traced)
 
     @property
-    def torch(self) -> torch.Tensor:
+    def torch(self) -> LazyTracedTensor:
         return self._traced_array
 
     @property

--- a/source/isaaclab/test/utils/test_leapp_indexed_state_input.py
+++ b/source/isaaclab/test/utils/test_leapp_indexed_state_input.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unit tests for LEAPP indexed state inputs."""
+
+from types import SimpleNamespace
+
+import torch
+import warp as wp
+
+import isaaclab.utils.leapp.utils as leapp_utils
+from isaaclab.utils.leapp.leapp_semantics import LeappTensorSemantics, joint_names_resolver
+from isaaclab.utils.leapp.utils import TracedProxyArray
+from isaaclab.utils.warp.proxy_array import ProxyArray
+
+
+def test_traced_proxy_array_annotates_indexed_joint_subset(monkeypatch):
+    """Indexed joint-state reads become indexed LEAPP input tensors."""
+
+    all_joint_names = [
+        "joint1",
+        "joint2",
+        "joint3",
+        "joint4",
+        "joint5",
+        "joint6",
+        "joint7",
+        "finger_joint",
+        "left_inner_knuckle_joint",
+        "right_inner_knuckle_joint",
+        "right_outer_knuckle_joint",
+        "left_outer_finger_joint",
+        "right_outer_finger_joint",
+    ]
+    arm_joint_ids = list(range(7))
+    arm_joint_names = all_joint_names[:7]
+    base_tensor = torch.arange(13, dtype=torch.float32).reshape(1, 13)
+    proxy_array = ProxyArray(wp.from_torch(base_tensor))
+    real_data = SimpleNamespace(joint_names=all_joint_names)
+    semantics = LeappTensorSemantics(
+        kind="state/joint/position",
+        element_names_resolver=joint_names_resolver,
+    )
+    cache = {}
+    captured = []
+
+    def fake_input_tensors(task_name, tensor_semantics):
+        captured.append((task_name, tensor_semantics))
+        return tensor_semantics.ref
+
+    monkeypatch.setattr(leapp_utils.annotate, "input_tensors", fake_input_tensors)
+
+    traced = TracedProxyArray(
+        proxy_array,
+        input_name="robot_joint_pos",
+        semantics_meta=semantics,
+        real_data=real_data,
+        entity_name="robot",
+        property_name="joint_pos",
+        task_name="TestTask-v0",
+        cache=cache,
+    )
+
+    result = traced.torch[:, arm_joint_ids]
+
+    torch.testing.assert_close(result, base_tensor[:, arm_joint_ids])
+    assert len(captured) == 1
+    task_name, tensor_semantics = captured[0]
+    assert task_name == "TestTask-v0"
+    assert tensor_semantics.name == "robot_joint_pos"
+    assert tensor_semantics.ref.shape == (1, 7)
+    assert tensor_semantics.kind == "state/joint/position"
+    assert tensor_semantics.element_names == [arm_joint_names]
+    assert tensor_semantics.extra == {"isaaclab_connection": "state:robot:joint_pos"}
+
+    cached = traced.torch[:, arm_joint_ids]
+
+    torch.testing.assert_close(cached, result)
+    assert len(captured) == 1

--- a/source/isaaclab/test/utils/test_leapp_observation_input.py
+++ b/source/isaaclab/test/utils/test_leapp_observation_input.py
@@ -11,8 +11,8 @@ import torch
 
 import isaaclab.utils.leapp.export_annotator as export_annotator
 from isaaclab.utils.leapp import (
-    ExportPatcher,
     XYZ_ELEMENT_NAMES,
+    ExportPatcher,
     leapp_observation_input,
     resolve_leapp_element_names,
     resolve_leapp_observation_input_semantics,


### PR DESCRIPTION
# Description

This PR makes LEAPP state input export index-aware.

Previously, LEAPP annotated simulator state tensors when `.torch` was accessed, before observation-term indexing was applied. For observation terms such as:

```python
asset.data.joint_pos.torch[:, asset_cfg.joint_ids]